### PR TITLE
Set token to null when expired

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -220,6 +220,8 @@ func LoginRequired() negroni.HandlerFunc {
 		s := sessions.GetSession(r)
 		token := unmarshallToken(s)
 		if token == nil || token.IsExpired() {
+			// Set token to null to avoid redirection loop
+			SetToken(r, nil)
 			next := url.QueryEscape(r.URL.RequestURI())
 			http.Redirect(rw, r, PathLogin+"?next="+next, http.StatusFound)
 		} else {


### PR DESCRIPTION
Fix loop redirection when "/" is set to restricted and token is invalid (Set token to nil in order to redirect to AuthCodeURL)
