### PR TITLE
Fix compatibility with golang/oauth2 (cf: a568078)

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -146,6 +146,7 @@ func NewOAuth2Provider(opts *Options, authUrl, tokenUrl string) negroni.HandlerF
 		ClientID:     opts.ClientID,
 		ClientSecret: opts.ClientSecret,
 		Scopes:       opts.Scopes,
+		RedirectURL:  opts.RedirectURL,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  authUrl,
 			TokenURL: tokenUrl,


### PR DESCRIPTION
Fix compatibilities with commit a568078 from golang/oauth2 repository.

To me NewOauth2Provider looks clearer with 'authUrl' and 'tokenUrl' as args instead of being part of an option array (it was also easier to use).
Let me know if you want it back an option array.
