### PR TITLE
use canonical oauth2 import

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/codegangsta/negroni"
 	sessions "github.com/goincremental/negroni-sessions"
-	"github.com/golang/oauth2"
+	"golang.org/x/oauth2"
 )
 
 const (


### PR DESCRIPTION
fixes these warnings (new in go 1.4):

```
package github.com/goincremental/negroni-oauth2
	imports github.com/golang/oauth2
	imports github.com/golang/oauth2
	imports github.com/golang/oauth2: code in directory /Users/rgarcia/go/src/github.com/golang/oauth2 expects import "golang.org/x/oauth2"
```