### PR TITLE
Get method was added to Tokens interface

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -60,7 +60,10 @@ type Tokens interface {
 	Valid() bool
 	ExpiryTime() time.Time
 	ExtraData(string) interface{}
+	Get() Token
 }
+
+type Token oauth2.Token
 
 type token struct {
 	oauth2.Token
@@ -98,6 +101,11 @@ func (t *token) ExpiryTime() time.Time {
 // String returns the string representation of the token.
 func (t *token) String() string {
 	return fmt.Sprintf("tokens: %v", t)
+}
+
+// Returns oauth2.Token.
+func (t *token) Get() Token {
+	return (Token)(t.Token)
 }
 
 // Returns a new Google OAuth 2.0 backend endpoint.


### PR DESCRIPTION
If I want to use "golang.org/x/oauth2" (which is under the hood of the negroni-auth2) - I need a way to easily get oauth2.Token. I cant simply cast like this tk = (goauth.Token)(token) (where goauth is import of golang.org/x/oauth2 and token := oauth2.GetToken(req)), so I propose this addition for Tokens interface.