### PR TITLE
Import github.com/{codegangsta→urfave}/negroni

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/codegangsta/negroni"
 	oauth2 "github.com/goincremental/negroni-oauth2"
 	sessions "github.com/goincremental/negroni-sessions"
 	"github.com/goincremental/negroni-sessions/cookiestore"
+	"github.com/urfave/negroni"
 )
 
 func main() {

--- a/examples/main.go
+++ b/examples/main.go
@@ -19,11 +19,11 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/codegangsta/negroni"
 	oauth2 "github.com/goincremental/negroni-oauth2"
 	sessions "github.com/goincremental/negroni-sessions"
 	"github.com/goincremental/negroni-sessions/cookiestore"
 	"github.com/joho/godotenv"
+	"github.com/urfave/negroni"
 )
 
 func getEnv(key string, defaultValue string) string {

--- a/oauth2.go
+++ b/oauth2.go
@@ -26,8 +26,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/codegangsta/negroni"
 	sessions "github.com/goincremental/negroni-sessions"
+	"github.com/urfave/negroni"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/codegangsta/negroni"
 	sessions "github.com/goincremental/negroni-sessions"
 	"github.com/goincremental/negroni-sessions/cookiestore"
+	"github.com/urfave/negroni"
 )
 
 func Test_LoginRedirect(t *testing.T) {


### PR DESCRIPTION
Changing negroni-oauth2 to use the urfave/negroni library (recently renamed from codegangsta/urfave) resolved `interface conversion: *negroni.responseWriter is not negroni.ResponseWriter: missing method Before` panics I was receiving when attempting something very similar to the example.

The same change was recently applied to https://github.com/GoIncremental/negroni-sessions/pull/14
